### PR TITLE
Fix build issue with macOS target version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import Foundation
 
 let buildDynamic = ProcessInfo.processInfo.environment["NODE_SWIFT_BUILD_DYNAMIC"] == "1"
 let enableEvolution = ProcessInfo.processInfo.environment["NODE_SWIFT_ENABLE_EVOLUTION"] == "1"
+let targetMacVersion = ProcessInfo.processInfo.environment["NODE_SWIFT_TARGET_MAC_VERSION"]!
 
 let baseSwiftSettings: [SwiftSetting] = [
 //    .unsafeFlags(["-Xfrontend", "-warn-concurrency"])
@@ -12,6 +13,7 @@ let baseSwiftSettings: [SwiftSetting] = [
 
 let package = Package(
     name: "node-swift",
+    platforms: [.macOS(targetMacVersion)],
     products: [
         .library(
             name: "NodeAPI",

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import Foundation
 
 let buildDynamic = ProcessInfo.processInfo.environment["NODE_SWIFT_BUILD_DYNAMIC"] == "1"
 let enableEvolution = ProcessInfo.processInfo.environment["NODE_SWIFT_ENABLE_EVOLUTION"] == "1"
-let targetMacVersion = ProcessInfo.processInfo.environment["NODE_SWIFT_TARGET_MAC_VERSION"]!
+let targetMacVersion = ProcessInfo.processInfo.environment["NODE_SWIFT_TARGET_MAC_VERSION"] ?? "10.15"
 
 let baseSwiftSettings: [SwiftSetting] = [
 //    .unsafeFlags(["-Xfrontend", "-warn-concurrency"])


### PR DESCRIPTION
# Problem

In the `webapp/frontend/desktop` running `yarn dev` throws an error:

![image](https://github.com/amieso/node-swift/assets/648039/5f2e963e-9fc4-4937-ab54-aa362755809f)

![image](https://github.com/amieso/node-swift/assets/648039/dcae5772-123f-4117-8b52-702eff1a88b3)

# Solution

The proper macOS version target is passed by env variable, so using it fixes the problem.